### PR TITLE
Add partial support for Edge Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,18 @@ export default function Component() {
 
 [Clic to read more about the Router Hook](#router-hook).
 
+[Why Intl-T?](#why-intl-t)
+
+### Edge Runtime Support Warning
+
+_Edge environments, such as Cloudflare Workers, Vercel Edge Functions, and Cloudflare Pages, are only partially supported and have various limitations and caveats._
+
+_Since `new Function` cannot be executed in edge environments, Translationn Node Proxies created from a new function cannot be functions anymore. This means you won't be able to call them directly. Instead, you'll need to use methods like `.use` or `.get` to perform actions._
+
+_The upside is that, since these proxies become string objects rather than function objects, they offer better compatibility in some environments and eliminate the need for workarounds such as React Patch. However, this limitation only applies to edge environments._
+
+_The current solution is a temporary workaround. In the future, full compatibility will be achieved, as there are ways in JavaScript that can provide the desired behavior and even allow you to choose between string objects or function objects as needed, thus avoiding the need for workarounds like the React Patch._
+
 ## Why Intl-T?
 
 > Why Intl-T instead of Other i18n Libraries

--- a/README.md
+++ b/README.md
@@ -1476,7 +1476,19 @@ _Edge environments, such as Cloudflare Workers, Vercel Edge Functions, and Cloud
 
 _Since `new Function` cannot be executed in edge environments, Translationn Node Proxies created from a new function cannot be functions anymore. This means you won't be able to call them directly. Instead, you'll need to use methods like `.use` or `.get` to perform actions._
 
-_The upside is that, since these proxies become string objects rather than function objects, they offer better compatibility in some environments and eliminate the need for workarounds such as React Patch. However, this limitation only applies to edge environments._
+```ts
+// from:
+const t = getTranslation();
+t("hello");
+t.greetings({ name: "John" });
+// to:
+const t = getTranslation(); // Also hooks lose their proxy properties
+t.get("hello"); // or t.hello
+t.greetings.use({ name: "John" });
+// .use and .get are aliases
+```
+
+_The upside is that, since these proxies become string objects rather than function objects, this offers better compatibility in some environments and eliminates the need for workarounds such as React Patch. However, this limitation only applies to edge environments._
 
 _The current solution is a temporary workaround. In the future, full compatibility will be achieved, as there are ways in JavaScript that can provide the desired behavior and even allow you to choose between string objects or function objects as needed, thus avoiding the need for workarounds like the React Patch._
 

--- a/src/core/translation.ts
+++ b/src/core/translation.ts
@@ -22,7 +22,7 @@ import { injectVariables } from "../tools/inject";
 import { hydration, isClient, isEdge } from "../state";
 import { getLocales } from "./dynamic";
 
-const TranslationFunction = isEdge ? Object : Function;
+const TranslationFunction = (isEdge ? Object : Function) as FunctionConstructor;
 
 abstract class TranslationProxy extends TranslationFunction {
   public name = "Translation";

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,16 +15,16 @@ export const locale = isClient ? (navigator["language" as keyof typeof navigator
 export const timeZone = options.timeZone;
 export const now = new Date();
 export let hydration: boolean;
+export let isEdge: boolean;
 
 try {
   hydration = Boolean(process);
 } catch {
-  hydration = false;
+  isEdge = !("window" in globalThis);
 }
 
 export const state: State = {
   timeZone,
   locale,
   now,
-  hydration,
 };

--- a/src/tools/inject.ts
+++ b/src/tools/inject.ts
@@ -1,6 +1,9 @@
 // oxlint-disable no-eval
 import type { Values, Content, Variables } from "../types";
 import { format } from "./format";
+import { isEdge } from "../state";
+
+if (isEdge) globalThis.eval = (v: any) => v;
 
 export function nested(content: string) {
   const matches = content.matchAll(/(?<!`)({|})/g);


### PR DESCRIPTION
Partial support for Edge Environments. These environments have various limitations, such as the inability to execute dynamic code using `eval` or `new Function`, which are commonly restricted due to security and performance constraints.

## Context

_Since `new Function` cannot be executed in edge environments, Translation Node Proxies created from a new function cannot be functions anymore. This means you won't be able to call them directly. Instead, you'll need to use methods like `.use` or `.get` to perform actions._

This solution is a temporary workaround. In the future, full compatibility will be achieved, as there are ways in JavaScript that can provide the desired behavior and even allow you to choose between string objects or function objects as needed, thus avoiding the need for workarounds like the React Patch.

## Related
- #1
Add partial support for Edge Environments such as Cloudflare Workers